### PR TITLE
Fix issue with `isless(x,y)` for ordered semirings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Releases
 
+## [0.5.2](https://github.com/FAST-ASR/Semirings.jl/releases/tag/v0.5.1) - 08.06.2022
+### Fixed
+- `isless(x, y)` not defined for `Ordered` semirings (e.g. LogSemiring, TropicalSemiring,...)
+
 ## [0.5.1](https://github.com/FAST-ASR/Semirings.jl/releases/tag/v0.5.1) - 08.06.2022
 ### Added
 - compatibility with Julia 1.6

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Semirings"
 uuid = "900aad66-9ca5-44d4-b043-321c62cb7767"
 authors = ["Lucas Ondel <lucas.ondel@gmail.com>", "Martin Kocour <ikocour@fit.vut.cz>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -67,8 +67,8 @@ Base.typemax(T::Type{<:Semiring}) = Base.typemax(IsOrdered(T), T)
 Base.typemax(x::Semiring) = Base.typemax(IsOrdered(typeof(x)), typeof(x))
 Base.typemax(::Type{Unordered}, ::Type{<:Semiring}) = _notdefinedfor(Unordered)
 
-Base.:<(x::Tx, y::Ty) where {Tx<:Semiring, Ty<:Semiring} =
-    Base.:<(promote_type(IsOrdered(Tx), IsOrdered(Ty)), x, y)
-Base.:<(::Type{Unordered}, x::Semiring, y::Semiring) = _notdefinedfor(Unordered)
-Base.:<(::Type{Ordered}, x::Semiring, y::Semiring) = val(x) < val(y)
+Base.isless(x::Tx, y::Ty) where {Tx<:Semiring, Ty<:Semiring} =
+    Base.isless(promote_type(IsOrdered(Tx), IsOrdered(Ty)), x, y)
+Base.isless(::Type{Unordered}, x::Semiring, y::Semiring) = _notdefinedfor(Unordered)
+Base.isless(::Type{Ordered}, x::Semiring, y::Semiring) = val(x) < val(y)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,7 @@ end
     for T in filter(x -> IsOrdered(x) == Ordered, Ts)
         @test IsOrdered(T) == Ordered
         @test one(T) > zero(T)
+        @test maximum([T(2), T(3)]) == T(3)
     end
 
     # Not divisible semirings


### PR DESCRIPTION
This fix solves the issue with isless function for ordered semering. Isless was not defined for orered semirings.