### PR TITLE
Fix dictionary search

### DIFF
--- a/src/monoidtype.jl
+++ b/src/monoidtype.jl
@@ -12,6 +12,7 @@ val(x::Monoid) = x.val
 Base.promote_rule(x::Type{Monoid}, y::Type{Number}) = x
 Base.:(==)(x::Monoid, y::Monoid) = val(x) == val(y)
 Base.:(≈)(x::Monoid, y::Monoid) = val(x) ≈ val(y)
+Base.hash(x::Monoid, h::UInt) = hash(val(x), h)
 Base.one(x::Monoid) = one(typeof(x))
 Base.show(io::IO, x::Monoid) = print(io, typeof(x), "(", val(x),  ")")
 Base.show(io::IO, m::MIME"text/plain", x::Monoid) = print(io, val(x))

--- a/src/semiringtype.jl
+++ b/src/semiringtype.jl
@@ -15,6 +15,7 @@ Base.abs(x::Semiring) = x
 Base.promote_rule(x::Type{Semiring}, y::Type{Number}) = x
 Base.:(==)(x::Semiring, y::Semiring) = val(x) == val(y)
 Base.:(≈)(x::Semiring, y::Semiring) = val(x) ≈ val(y)
+Base.hash(x::Semiring, h::UInt) = hash(val(x), h)
 Base.zero(x::Semiring) = zero(typeof(x))
 Base.one(x::Semiring) = one(typeof(x))
 Base.show(io::IO, x::Semiring) = print(io, typeof(x), "(", val(x),  ")")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,10 @@ end
 
     a, b = SequenceMonoid(tuple(1)), SequenceMonoid(tuple("a"))
     @test val(a * b) == tuple(1, "a")
+
+    @test SequenceMonoid((SubString("a"),)) == SequenceMonoid((String("a"),)) 
+    @test SequenceMonoid((SubString("a"),)) in keys(Dict(SequenceMonoid((String("a"),)) => 1))
+    @test SequenceMonoid((String("a"),)) in keys(Dict(SequenceMonoid((SubString("a"),)) => 1))
 end
 
 @testset "String monoid" begin


### PR DESCRIPTION
According to https://docs.julialang.org/en/v1/base/base/#Base.isequal, when `isequel` is override it is neccesary to override also `hash` method so search in dictionary is working as expected.